### PR TITLE
Huge reconstruction

### DIFF
--- a/src/builder.jl
+++ b/src/builder.jl
@@ -482,8 +482,8 @@ end
 
 ##
 # This constructor builds a lux chain that maps a configuration to the corresponding B^0 to B^L vectors 
-# What can be adjusted in its input are: (1) total polynomial degree; (2) correlation order; (3) largest L
-# (4) weight of the order of spherical harmonics; (5) specified radial basis
+# What can be adjusted in its input are: (1) spec_nlm as the specification of the AA bases; (2) largest L
+# (3) a set of categories; (4) specified radial basis; (5) symmetry group; ...
 
 function specnlm2spec1p(spec_nlm)
    spec1p = union(spec_nlm...)

--- a/src/builder.jl
+++ b/src/builder.jl
@@ -376,8 +376,8 @@ function cgmatrix(L1,L2)
       for l = 0:L1+L2
          if abs(ν)<=l
             position = ν + l + 1
-            # cgm[i, l^2+position] = (-1)^q * cg(L1,p,L2,q,l,ν) 
-            cgm[i, l^2+position] = cg(L1,p,L2,q,l,ν) 
+            cgm[i, l^2+position] = (-1)^q * cg(L1,p,L2,q,l,ν) 
+            # cgm[i, l^2+position] = cg(L1,p,L2,q,l,ν) 
             # cgm[i, l^2+position] = (-1)^q * sqrt( (2L1+1) * (2L2+1) ) / 2 / sqrt(π * (2l+1)) * cg(L1,0,L2,0,l,0) * cg(L1,p,L2,q,l,ν) 
          end
       end

--- a/src/builder.jl
+++ b/src/builder.jl
@@ -508,10 +508,13 @@ function equivariant_model(spec_nlm, L, d=3, categories=[]; radial_basis=legendr
    Rn = radial_basis(nmax)
    
    if !isempty(categories)
+      # Read categories from x
+      cat(x) = [ x[i].cat for i = 1:length(x) ]
       # Define categorical bases
+      # δs = CateBasis(categories) # TODO: this is not yet in P4ML ??
    end
    
-   spec1pidx = getspec1idx(spec1p, Rn, Ylm)
+   spec1pidx = isempty(categories) ? getspec1idx(spec1p, Rn, Ylm) : getspec1idx(spec1p, Rn, Ylm, δs)
    bA = P4ML.PooledSparseProduct(spec1pidx)
 
    if islong

--- a/src/builder.jl
+++ b/src/builder.jl
@@ -493,12 +493,8 @@ function specnlm2spec1p(spec_nlm)
 end
 
 function equivariant_model(spec_nlm, L, d=3, categories=[]; radial_basis=legendre_basis, group="O3", islong=true)
-   # first filter out those unfeasible spec_nlm
-   if !islong
-      filter_init = RPE_filter(L)
-   else
-      filter_init = RPE_filter_long(L)
-   end
+   # first filt out those unfeasible spec_nlm
+   filter_init = islong ? RPE_filter_long(L) : RPE_filter(L)
    spec_nlm = spec_nlm[findall(x -> filter_init(x) == 1, spec_nlm)]
    
    # from spec_nlm to all possible spec1p
@@ -548,6 +544,7 @@ function equivariant_model(spec_nlm, L, d=3, categories=[]; radial_basis=legendr
    # wrapping into lux layers
    l_Rn = P4ML.lux(Rn)
    l_Ylm = P4ML.lux(Ylm)
+   # l_δs = P4ML.lux(δs)
    l_bA = P4ML.lux(bA)
    l_bAA = P4ML.lux(bAA)
    

--- a/src/builder.jl
+++ b/src/builder.jl
@@ -527,9 +527,9 @@ function equivariant_model(spec_nlm, L, d=3, categories=[]; radial_basis=legendr
          spec[l+1] = [ [dict_spec1p[tmp[k][j]] for j = 1:length(tmp[k])] for k = 1:length(tmp) ]
       end
 
-      filter = RPE_filter_long(L)
-      tmp = spec_nlm[findall(x -> filter(x) == 1, spec_nlm)]
-      Spec = [ [dict_spec1p[tmp[k][j]] for j = 1:length(tmp[k])] for k = 1:length(tmp) ]
+      # filter = RPE_filter_long(L)
+      # tmp = spec_nlm[findall(x -> filter(x) == 1, spec_nlm)]
+      Spec = [ [dict_spec1p[spec_nlm[k][j]] for j = 1:length(spec_nlm[k])] for k = 1:length(spec_nlm) ]
       dict = Dict([Spec[i] => i for i = 1:length(Spec)])
       pos = [ [dict[spec[k][j]] for j = 1:length(spec[k])] for k = 1:L+1 ]
    

--- a/src/builder.jl
+++ b/src/builder.jl
@@ -492,7 +492,7 @@ function specnlm2spec1p(spec_nlm)
    return spec1p, lmax, nmax + 1
 end
 
-function ClusterExpansion_model(spec_nlm, L, d=3, categories=[]; radial_basis=legendre_basis, group="O3", islong=true)
+function equivariant_model(spec_nlm, L, d=3, categories=[]; radial_basis=legendre_basis, group="O3", islong=true)
    # first filter out those unfeasible spec_nlm
    if !islong
       filter_init = RPE_filter(L)
@@ -521,7 +521,7 @@ function ClusterExpansion_model(spec_nlm, L, d=3, categories=[]; radial_basis=le
    
       for l = 0:L
          filter = RPE_filter(l)
-         cgen = Rot3DCoeffs(l)
+         cgen = Rot3DCoeffs(l) # TODO: this should be made group related
 
          tmp = spec_nlm[findall(x -> filter(x) == 1, spec_nlm)]
          C[l+1] = _rpi_A2B_matrix(cgen, tmp)
@@ -536,7 +536,7 @@ function ClusterExpansion_model(spec_nlm, L, d=3, categories=[]; radial_basis=le
    
       bAA = P4ML.SparseSymmProd(Spec)
    else
-      cgen = Rot3DCoeffs(L)
+      cgen = Rot3DCoeffs(L) # TODO: this should be made group related
       C = _rpi_A2B_matrix(cgen, spec_nlm)
       Spec = [ [dict_spec1p[spec_nlm[k][j]] for j = 1:length(spec_nlm[k])] for k = 1:length(spec_nlm) ]
       bAA = P4ML.SparseSymmProd(Spec)

--- a/test/test_equivariance.jl
+++ b/test/test_equivariance.jl
@@ -109,7 +109,7 @@ println()
 @info("Tesing the last way of input - given n_list and l_list")
 
 for L = 0:Lmax
-   local F, luxchain, ps, st
+   local F, luxchain, ps, st, nn, ll
    
    nn = rand(0:2,4)
    ll = rand(0:2,4)

--- a/test/test_equivariance.jl
+++ b/test/test_equivariance.jl
@@ -10,7 +10,7 @@ include("wigner.jl")
 @info("Testing the chain that generates a single B basis")
 totdeg = 6
 ν = 2
-Lmax = 4
+Lmax = 2
 
 for L = 0:Lmax
    local F, luxchain, ps, st, F2, luxchain2, ps2, st2
@@ -179,7 +179,7 @@ println()
 nn = rand(0:2,4)
 ll = rand(0:2,4)
 while iseven(Lmax) != iseven(sum(ll))
-   ll = rand(0:2,4)
+   global ll = rand(0:2,4)
 end
 
 luxchain, ps, st = equivariant_SYY_model(nn,ll,L)

--- a/test/test_equivariance.jl
+++ b/test/test_equivariance.jl
@@ -5,14 +5,18 @@ using ACEbase.Testing: print_tf
 using Rotations, WignerD, BlockDiagonals
 using LinearAlgebra
 
-@info("Testing single vector case")
+@info("Testing the chain that generates a single B basis")
 totdeg = 6
 ν = 2
+Lmax = 4
 
-for L = 0:4
-   local F, luxchain, ps, st
-   luxchain, ps, st = luxchain_constructor(totdeg,ν,L;islong = false)
+for L = 0:Lmax
+   local F, luxchain, ps, st, F2, luxchain2, ps2, st2
+   luxchain, ps, st = equivariant_model(totdeg,ν,L;islong = false)
    F(X) = luxchain(X, ps, st)[1]
+   
+   luxchain2, ps2, st2 = equivariant_model(EquivariantModels.degord2spec_nlm(totdeg,ν,L; islong = false)[1:end-1],L;islong = false)
+   F2(X) = luxchain(X, ps2, st2)[1]
    
    @info("Tesing L = $L O(3) equivariance")
    for _ = 1:30
@@ -30,15 +34,114 @@ for L = 0:4
       end
    end
    println()
+   
+   @info("Tesing consistency between the two ways of input - in particular the ``closure'' of specifications")
+   for _ = 1:30
+      local X
+      X = [ @SVector(rand(3)) for i in 1:10 ]
+      print_tf(@test F(X) ≈ F2(X))
+   end
+   println()
+   
 end
 
+@info("Testing the chain that generates all B bases")
+totdeg = 6
+ν = 2
+L = Lmax
+luxchain, ps, st = equivariant_model(totdeg,ν,L;islong = true)
+F(X) = luxchain(X, ps, st)[1]
+luxchain2, ps2, st2 = equivariant_model(EquivariantModels.degord2spec_nlm(totdeg,ν,L; islong = true)[1:end-1],L;islong = true)
+F2(X) = luxchain(X, ps2, st2)[1]
+
+for ntest = 1:10
+   local X, θ, Q, QX
+   X = [ @SVector(rand(3)) for i in 1:10 ]
+   θ = rand() * 2pi
+   Q = RotXYZ(0, 0, θ)
+   QX = [SVector{3}(x) for x in Ref(Q) .* X]
+   
+   print_tf(@test F(X)[1] ≈ F(QX)[1])
+
+   for l = 2:L
+      D = wignerD(l-1, 0, 0, θ)
+      print_tf(@test norm.(Ref(D') .* F(X)[l] - F(QX)[l]) |> norm <1e-8)
+   end
+end
+println()
+
+@info("Consistency check")
+totdeg = 6
+ν = 2
+L = Lmax
+luxchain, ps, st = equivariant_model(totdeg,ν,L;islong = true);
+F(X) = luxchain(X, ps, st)[1]
+
+for l = 0:4
+   @info("Consistency check for L = $l")
+   local FF, luxchain, ps, st
+   luxchain, ps, st = equivariant_model(totdeg,ν,l;islong = false)
+   FF(X) = luxchain(X, ps, st)[1]
+   
+   for ntest = 1:20
+      X = [ @SVector(rand(3)) for i in 1:10 ]
+      print_tf(@test F(X)[l+1] == FF(X))
+   end
+   println()
+end
+
+@info("Tesing consistency between the two ways of input - in particular the ``closure'' of specifications")
+for _ = 1:10
+   local X
+   X = [ @SVector(rand(3)) for i in 1:10 ]
+   print_tf(@test length(F(X)) == length(F2(X)) && all([F(X)[i] ≈ F2(X)[i] for i = 1:length(F(X))]))
+end
+println()
+
+@info("Tesing the last way of input - given n_list and l_list")
+
+for L = 0:Lmax
+   local F, luxchain, ps, st
+   
+   nn = rand(0:2,4)
+   ll = rand(0:2,4)
+   while iseven(L) != iseven(sum(ll))
+      ll = rand(0:2,4)
+   end
+   luxchain, ps, st = equivariant_model(nn,ll,L;islong = false)
+   F(X) = luxchain(X, ps, st)[1]
+   
+   @info("Tesing L = $L O(3) equivariance")
+   for _ = 1:30
+      local X, θ, Q, QX
+      X = [ @SVector(rand(3)) for i in 1:10 ]
+      θ = rand() * 2pi
+      Q = RotXYZ(0, 0, θ)
+      # Q = rand_rot()
+      QX = [SVector{3}(x) for x in Ref(Q) .* X]
+      D = wignerD(L, 0, 0, θ)
+      if length(F(X)) == 0 
+         continue
+      end
+      if L == 0
+         print_tf(@test F(X) ≈ F(QX))
+      else
+         print_tf(@test F(X) ≈ Ref(D) .* F(QX))
+      end
+   end
+   println()
+end
+
+# We may want to get rid of it or use it in the future - to be discussed
 @info("Testing SYYVector case")
 totdeg = 6
 ν = 2
-L = 4
-luxchain, ps, st = luxchain_constructor(totdeg,ν,L;islong = true)
-local F
+L = Lmax
+luxchain, ps, st = equivariant_SYY_model(totdeg,ν,L);
 F(X) = luxchain(X, ps, st)[1]
+luxchain2, ps2, st2 = equivariant_SYY_model(EquivariantModels.degord2spec_nlm(totdeg,ν,L; islong = true)[1:end-1],L)
+F2(X) = luxchain(X, ps2, st2)[1]
+
 @info("Tesing L = $L O(3) full equivariance")
 
 for ntest = 1:20
@@ -53,11 +156,46 @@ for ntest = 1:20
 end
 println()
 
-## equivariant blocks
+@info("Tesing consistency between the two ways of input - in particular the ``closure'' of specifications")
+for _ = 1:10
+   local X
+   X = [ @SVector(rand(3)) for i in 1:10 ]
+   print_tf(@test length(F(X)) == length(F2(X)) && all([F(X)[i] ≈ F2(X)[i] for i = 1:length(F(X))]))
+end
+println()
+
+@info("Tesing the last way of input - given n_list and l_list")
+
+nn = rand(0:2,4)
+ll = rand(0:2,4)
+while iseven(Lmax) != iseven(sum(ll))
+   ll = rand(0:2,4)
+end
+
+luxchain, ps, st = equivariant_SYY_model(nn,ll,L)
+F(X) = luxchain(X, ps, st)[1]
+
+@info("Tesing L = $L O(3) full equivariance")
+
+for ntest = 1:20
+   local X, θ, Q, QX
+   X = [ @SVector(rand(3)) for i in 1:10 ]
+   θ = rand() * 2pi
+   Q = RotXYZ(0, 0, θ)
+   QX = [SVector{3}(x) for x in Ref(Q) .* X]
+   D = BlockDiagonal([ wignerD(l, 0, 0, θ) for l = 0:L] )
+   
+   print_tf(@test Ref(D) .* F(QX) ≈ F(X))
+end
+println()
+
+## TODO: This should eventually go into ACEhamiltonians.jl
+# equivariant blocks
+
 @info("Testing the chain that generates several equivariant blocks from a long vector")
 totdeg = 6
 ν = 2
-L = 4
+L = Lmax
 luxchain, ps, st = equivariant_luxchain_constructor(totdeg,ν,L)
 F(X) = luxchain(X, ps, st)[1]
 
@@ -82,54 +220,10 @@ for ntest = 1:10
 end
 println()
 
-## A second way - construct B^0, B^1, ..., B^L first
-@info("Testing the chain that generates all the B bases")
-totdeg = 6
-ν = 2
-L = 4
-luxchain, ps, st = luxchain_constructor_multioutput(totdeg,ν,L)
-F(X) = luxchain(X, ps, st)[1]
-
-for ntest = 1:10
-   local X, θ, Q, QX
-   X = [ @SVector(rand(3)) for i in 1:10 ]
-   θ = rand() * 2pi
-   Q = RotXYZ(0, 0, θ)
-   QX = [SVector{3}(x) for x in Ref(Q) .* X]
-   
-   print_tf(@test F(X)[1] ≈ F(QX)[1])
-
-   for l = 2:L
-      D = wignerD(l-1, 0, 0, θ)
-      print_tf(@test norm.(Ref(D') .* F(X)[l] - F(QX)[l]) |> norm <1e-8)
-   end
-end
-println()
-
-@info("Consistency check")
-totdeg = 6
-ν = 2
-L = 4
-luxchain, ps, st = luxchain_constructor_multioutput(totdeg,ν,L);
-F(X) = luxchain(X, ps, st)[1]
-
-for l = 0:4
-   @info("Consistency check for L = $l")
-   local FF, luxchain, ps, st
-   luxchain, ps, st = luxchain_constructor(totdeg,ν,l;islong = false)
-   FF(X) = luxchain(X, ps, st)[1]
-   
-   for ntest = 1:20
-      X = [ @SVector(rand(3)) for i in 1:10 ]
-      print_tf(@test F(X)[l+1] == FF(X))
-   end
-   println()
-end
-
 @info("Testing the equivariance of the second way of constructing equivariant bases")
 totdeg = 6
 ν = 1
-L = 4
+L = Lmax
 luxchain, ps, st = EquivariantModels.equivariant_luxchain_constructor_new(totdeg,ν,L);
 F(X) = luxchain(X, ps, st)[1]
 

--- a/test/test_equivariance.jl
+++ b/test/test_equivariance.jl
@@ -73,7 +73,7 @@ for ntest = 1:10
    for l = 2:L
       D = wigner_D(l-1,Matrix(Q))'
       # D = wignerD(l-1, 0, 0, θ)
-      print_tf(@test norm.(Ref(D') .* F(X)[l] - F(QX)[l]) |> norm <1e-8)
+      print_tf(@test norm.(Ref(D') .* F(X)[l] - F(QX)[l]) |> norm <1e-12)
    end
 end
 println()
@@ -85,7 +85,7 @@ L = Lmax
 luxchain, ps, st = equivariant_model(totdeg,ν,L;islong = true);
 F(X) = luxchain(X, ps, st)[1]
 
-for l = 0:4
+for l = 0:Lmax
    @info("Consistency check for L = $l")
    local FF, luxchain, ps, st
    luxchain, ps, st = equivariant_model(totdeg,ν,l;islong = false)
@@ -230,7 +230,7 @@ for ntest = 1:10
       # D1 = wignerD(l1, 0, 0, θ)
       # D2 = wignerD(l2, 0, 0, θ)
       if F(X)[i] |> length ≠ 0
-         print_tf(@test norm(Ref(D1') .* F(X)[i] .* Ref(D2) - F(QX)[i]) < 1e-8) 
+         print_tf(@test norm(Ref(D1') .* F(X)[i] .* Ref(D2) - F(QX)[i]) < 1e-12) 
       end
    end
 end

--- a/test/wigner.jl
+++ b/test/wigner.jl
@@ -1,0 +1,76 @@
+using StaticArrays
+
+"""
+Index of entries in D matrix (sign included)
+"""
+struct D_Index
+	sign::Int64
+	μ::Int64
+	m::Int64
+end
+
+"""
+auxiliary matrix - indices for D matrix
+"""
+wigner_D_indices(L::Integer) = (   @assert L >= 0;
+		[ D_Index(1, i - 1 - L, j - 1 - L) for j = 1:2*L+1, i = 1:2*L+1] )
+
+Base.adjoint(idx::D_Index) = D_Index( (-1)^(idx.μ+idx.m), - idx.μ, - idx.m)
+
+"""
+One entry of the Wigner-big-D matrix, `[D^l]_{mu, m}`
+"""
+wigner_D(μ,m,l,α,β,γ) = (exp(-im*α*m) * wigner_d(m,μ,l,β)  * exp(-im*γ*μ))'
+
+
+
+"""
+One entry of the Wigner-small-d matrix,
+
+Wigner small d, modified from
+```
+https://github.com/cortner/SlaterKoster.jl/blob/
+8dceecb073709e6448a7a219ed9d3a010fa06724/src/code_generation.jl#L73
+```
+"""
+function wigner_d(μ, m, l, β)
+    fc1 = factorial(l+m)
+    fc2 = factorial(l-m)
+    fc3 = factorial(l+μ)
+    fc4 = factorial(l-μ)
+    fcm1 = sqrt(fc1 * fc2 * fc3 * fc4)
+
+    cosb = cos(β / 2.0)
+    sinb = sin(β / 2.0)
+
+    p = m - μ
+    low  = max(0,p)
+    high = min(l+m,l-μ)
+
+    temp = 0.0
+    for s = low:high
+       fc5 = factorial(s)
+       fc6 = factorial(l+m-s)
+       fc7 = factorial(l-μ-s)
+       fc8 = factorial(s-p)
+       fcm2 = fc5 * fc6 * fc7 * fc8
+       pow1 = 2 * l - 2 * s + p
+       pow2 = 2 * s - p
+       temp += (-1)^(s+p) * cosb^pow1 * sinb^pow2 / fcm2
+    end
+    temp *= fcm1
+
+    return temp
+end
+
+mat2ang(Q) = mod(atan(Q[2,3],Q[1,3]),2pi), acos(Q[3,3]), mod(atan(Q[3,2],-Q[3,1]),2pi);
+
+
+function wigner_D(L::Integer, Q::AbstractMatrix)
+	D = wigner_D_indices(L);
+	α, β, γ = mat2ang(Q);
+	Mat_D = [ wigner_D(D[i,j].μ, D[i,j].m, L, α, β, γ)
+			    for i = 1:2*L+1, j = 1:2*L+1 ]
+   # NB: type instability here, but performance is not important.
+	return SMatrix{2L+1, 2L+1, ComplexF64}(Mat_D)
+end


### PR DESCRIPTION
This PR provides a huge reconstruction of this package. 

In this version, the codes generate a chain that constructs an or all equivariant basi(e)s from a given list of AA specifications (no matter whether complete or not - it will be auto-completed before symmetrization).  
In particular, the chain is divided into two parts: (1) x -> A -> AA; (2) AA -> B_L or [B_i]_{i=0}^L - i.e. a symmetrization layer

Other options for inputs are (1) total degree and correlation order $\nu$; (2) a pair of n_list and l_list.

Those codes for SYYVector were also updated and kept just in case it is usable at some point. 