### PR TITLE
Remove direct dependency to DecoratedParticles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,5 +25,7 @@ WignerD = "87c4ff3e-34df-11e9-37a7-516cea4e0402"
 
 [compat]
 julia = "1"
+Lux = "0.5"
+LuxCore = "0.1"
 Polynomials4ML = "0.3.1"
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,29 +1,21 @@
-name = "EquivariantModels"
-uuid = "73ee3e68-46fd-466f-9c56-451dc0291ebc"
-authors = ["Christoph Ortner <christophortner@gmail.com> and contributors"]
-version = "0.0.5"
-
 [deps]
 ACEbase = "14bae519-eb20-449c-a949-9c58ed33163e"
 BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
-ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+EquivariantModels = "73ee3e68-46fd-466f-9c56-451dc0291ebc"
+DecoratedParticles = "023d0394-cb16-4d2d-a5c7-724bed42bbb6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-LinearOperators = "5c8ed15e-5a4c-59e4-a42b-c7e8811fb125"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxCore = "bb33d45b-7691-41d6-9220-0943567d0623"
-Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Polynomials4ML = "03c4bcba-a943-47e9-bfa1-b1661fc2974f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RepLieGroups = "f07d36f2-91c4-427a-b67b-965fe5ebe1d2"
-ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WignerD = "87c4ff3e-34df-11e9-37a7-516cea4e0402"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
 
 [compat]
-julia = "1"
-Polynomials4ML = "0.3.1"
-
+DecoratedParticles = "0.0.5, 0.0.6, 0.0.7"


### PR DESCRIPTION
This will create separate Project.toml to separate [DecoratedParticles.jl](https://github.com/ACEsuit/DecoratedParticles.jl) from the dependencies and thus removing requirement for AtomsBase v0.4. Because the main package does not depend form AtomsBase itself.

This is needed to fix https://github.com/ACEsuit/ACEpotentials.jl/issues/297